### PR TITLE
fix padding on nav and improve carousel behavior on mobile

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,7 +3,7 @@ import { NavLink } from "react-router-dom";
 const Navigation = () => {
   return (
     <nav className="fixed top-3 right-3 z-50">
-      <div className="bg-white/20 backdrop-blur-md rounded-full shadow-lg px-6 py-3 border border-white/20">
+      <div className="bg-white/20 backdrop-blur-md rounded-full shadow-lg px-6 pt-3 pb-1 border border-white/20">
         <ul className="flex space-x-8">
           <li>
             <NavLink


### PR DESCRIPTION
### Description:

1. Improve carousel behavior on mobile (the manual scroll was "sticky" before. These changes make it smoother. However, auto-scroll is still not working on mobile)

Context^
- iOS Safari and Android Chrome aggressively throttle or block requestAnimationFrame and setInterval when:
   - The user is not actively interacting with the page.
   - The scroll container is not focused.
   - The browser is conserving battery/performance.
- Programmatic scrolling (scrollLeft += x) does not behave the same way on mobile as on desktop — it's deprioritized.
- Even scrollTo() or CSS scroll-behavior: smooth won’t trigger automatically unless in direct user interaction context.

2. Fix nav bar padding (remove extra from beneath the text)